### PR TITLE
Preserve additional values of message

### DIFF
--- a/sensor.js
+++ b/sensor.js
@@ -25,7 +25,7 @@ module.exports = function(RED) {
                         topic = input_msg.topic;
                 }
 
-                var msg = { payload: value, topic: topic };
+                var msg = { ...input_msg, payload: value, topic: topic };
                 node.send(msg);
             });
         }


### PR DESCRIPTION
This flow doesn't work, because a new message object is created. If an input message contains additional properties, they are discarded.
![grafik](https://user-images.githubusercontent.com/1523157/83809962-a4109e80-a6b7-11ea-9b7d-fea6e5a530ee.png)

My change transfers the properties of the `input_msg` to the new `msg` object. If `input_msg` is `null`, the new message object just contains `{ payload: value, topic: topic }`.